### PR TITLE
Allow use of variable to enable cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ module "collector_kinesis" {
 | <a name="input_byte_limit"></a> [byte\_limit](#input\_byte\_limit) | The amount of bytes to buffer events before pushing them to Kinesis | `number` | `1000000` | no |
 | <a name="input_cloudwatch_logs_enabled"></a> [cloudwatch\_logs\_enabled](#input\_cloudwatch\_logs\_enabled) | Whether application logs should be reported to CloudWatch | `bool` | `true` | no |
 | <a name="input_cloudwatch_logs_retention_days"></a> [cloudwatch\_logs\_retention\_days](#input\_cloudwatch\_logs\_retention\_days) | The length of time in days to retain logs for | `number` | `7` | no |
+| <a name="input_cookie_enabled"></a> [cookie\_enabled](#input\_cookie\_enabled) | Whether server side cookies are enabled or not | `boolean` | `true` | no |
 | <a name="input_cookie_domain"></a> [cookie\_domain](#input\_cookie\_domain) | Optional first party cookie domain for the collector to set cookies on (e.g. acme.com) | `string` | `""` | no |
 | <a name="input_custom_paths"></a> [custom\_paths](#input\_custom\_paths) | Optional custom paths that the collector will respond to, typical paths to override are '/com.snowplowanalytics.snowplow/tp2', '/com.snowplowanalytics.iglu/v1' and '/r/tp2'. e.g. { "/custom/path/" : "/com.snowplowanalytics.snowplow/tp2"} | `map(string)` | `{}` | no |
 | <a name="input_enable_auto_scaling"></a> [enable\_auto\_scaling](#input\_enable\_auto\_scaling) | Whether to enable auto-scaling policies for the service | `bool` | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -199,6 +199,7 @@ locals {
   collector_hocon = templatefile("${path.module}/templates/config.hocon.tmpl", {
     port             = var.ingress_port
     paths            = var.custom_paths
+    cookie_enabled   = var.cookie_enabled
     cookie_domain    = var.cookie_domain
     good_stream_name = var.good_stream_name
     bad_stream_name  = var.bad_stream_name

--- a/templates/config.hocon.tmpl
+++ b/templates/config.hocon.tmpl
@@ -21,7 +21,7 @@ collector {
     secure = true
   }
   cookie {
-    enabled = true
+    enabled = ${cookie_enabled}
     expiration = "365 days"
     name = sp
     domains = []

--- a/variables.tf
+++ b/variables.tf
@@ -161,6 +161,12 @@ variable "custom_paths" {
   type        = map(string)
 }
 
+variable "cookie_enabled" {
+  description = "Whether server side cookies are enabled or not"
+  default     = true
+  type        = bool
+}
+
 variable "cookie_domain" {
   description = "Optional first party cookie domain for the collector to set cookies on (e.g. acme.com)"
   default     = ""


### PR DESCRIPTION
#### Overview

We want to be able to disable server side cookies through Terraform.

This makes the following configuration possible via inputs.

```
cookie {
  enabled: false
}
```